### PR TITLE
Fix renderflex overflow and enable back invoked callback

### DIFF
--- a/jashoo/android/app/src/main/AndroidManifest.xml
+++ b/jashoo/android/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
     <application
         android:label="jashoo"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:enableOnBackInvokedCallback="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/jashoo/lib/screens/dashboard/dashboard_screen.dart
+++ b/jashoo/lib/screens/dashboard/dashboard_screen.dart
@@ -346,119 +346,129 @@ class _DashBoardScreenState extends State<DashBoardScreen> {
 
   /// ----------------- PROFILE -----------------
   Widget _buildProfile() {
-    return Column(
-      children: [
-        const SizedBox(height: 16),
-        Row(
-          children: const [
-            SizedBox(width: 16),
-            CircleAvatar(
-              radius: 36,
-              backgroundColor: primaryColor,
-              child: Icon(Icons.person, color: Colors.white, size: 40),
-            ),
-            SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                'Your Profile',
-                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+    return SafeArea(
+      child: Column(
+        children: [
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: Column(
+                children: [
+                  const SizedBox(height: 16),
+                  Row(
+                    children: const [
+                      SizedBox(width: 16),
+                      CircleAvatar(
+                        radius: 36,
+                        backgroundColor: primaryColor,
+                        child: Icon(Icons.person, color: Colors.white, size: 40),
+                      ),
+                      SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          'Your Profile',
+                          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton.icon(
+                            onPressed: () => Navigator.pushNamed(context, '/profileUpdate'),
+                            icon: const Icon(Icons.edit),
+                            label: const Text('Edit'),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: OutlinedButton.icon(
+                            onPressed: () => Navigator.pushNamed(context, '/gamification'),
+                            icon: const Icon(Icons.emoji_events),
+                            label: const Text('Points'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton.icon(
+                            onPressed: () => Navigator.pushNamed(context, '/savings'),
+                            icon: const Icon(Icons.savings),
+                            label: const Text('Savings'),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: OutlinedButton.icon(
+                            onPressed: () => Navigator.pushNamed(context, '/loans'),
+                            icon: const Icon(Icons.account_balance),
+                            label: const Text('Loans'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton.icon(
+                            onPressed: () => Navigator.pushNamed(context, '/insurance'),
+                            icon: const Icon(Icons.health_and_safety),
+                            label: const Text('Insurance'),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: OutlinedButton.icon(
+                            onPressed: () => Navigator.pushNamed(context, '/help'),
+                            icon: const Icon(Icons.help),
+                            label: const Text('Help'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
               ),
             ),
-          ],
-        ),
-        const SizedBox(height: 16),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: Row(
-            children: [
-              Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () => Navigator.pushNamed(context, '/profileUpdate'),
-                  icon: const Icon(Icons.edit),
-                  label: const Text('Edit'),
-                ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () => Navigator.pushNamed(context, '/gamification'),
-                  icon: const Icon(Icons.emoji_events),
-                  label: const Text('Points'),
-                ),
-              ),
-            ],
           ),
-        ),
-        const SizedBox(height: 8),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: Row(
-            children: [
-              Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () => Navigator.pushNamed(context, '/savings'),
-                  icon: const Icon(Icons.savings),
-                  label: const Text('Savings'),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16),
+            child: Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: () => Navigator.pushNamed(context, '/changePassword'),
+                    icon: const Icon(Icons.lock),
+                    label: const Text('Password'),
+                  ),
                 ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () => Navigator.pushNamed(context, '/loans'),
-                  icon: const Icon(Icons.account_balance),
-                  label: const Text('Loans'),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: () => Navigator.pushNamed(context, '/logout'),
+                    icon: const Icon(Icons.logout, color: Colors.red),
+                    label: const Text('Logout'),
+                  ),
                 ),
-              ),
-            ],
-          ),
-        ),
-        const SizedBox(height: 8),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: Row(
-            children: [
-              Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () => Navigator.pushNamed(context, '/insurance'),
-                  icon: const Icon(Icons.health_and_safety),
-                  label: const Text('Insurance'),
-                ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () => Navigator.pushNamed(context, '/help'),
-                  icon: const Icon(Icons.help),
-                  label: const Text('Help'),
-                ),
-              ),
-            ],
-          ),
-        ),
-        const Spacer(),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 16),
-          child: Row(
-            children: [
-              Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () => Navigator.pushNamed(context, '/changePassword'),
-                  icon: const Icon(Icons.lock),
-                  label: const Text('Password'),
-                ),
-              ),
-              const SizedBox(width: 8),
-              Expanded(
-                child: OutlinedButton.icon(
-                  onPressed: () => Navigator.pushNamed(context, '/logout'),
-                  icon: const Icon(Icons.logout, color: Colors.red),
-                  label: const Text('Logout'),
-                ),
-              ),
-            ],
-          ),
-        )
-      ],
+              ],
+            ),
+          )
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
Enable Android 13+ back callback and fix RenderFlex overflow in the profile tab by making content scrollable.

The `W/WindowOnBackDispatcher` warning is resolved by enabling `android:enableOnBackInvokedCallback="true"` in the manifest. The `RenderFlex overflow` in the profile tab, often triggered by the keyboard, is fixed by wrapping the main content in a `SingleChildScrollView` and pinning the bottom action buttons, ensuring the UI adapts to available space.

---
<a href="https://cursor.com/background-agent?bcId=bc-550ccb67-4889-42e3-9c0b-1bc3c92c75d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-550ccb67-4889-42e3-9c0b-1bc3c92c75d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

